### PR TITLE
feat: add enableUILibraryTheming option to settings

### DIFF
--- a/sdk/src/anima.ts
+++ b/sdk/src/anima.ts
@@ -82,6 +82,7 @@ export class Anima {
         styling: settings.styling,
         uiLibrary: settings.uiLibrary,
         enableTranslation: settings.enableTranslation,
+        enableUILibraryTheming: settings.enableUILibraryTheming,
       }),
     });
 

--- a/sdk/src/settings.ts
+++ b/sdk/src/settings.ts
@@ -18,6 +18,7 @@ const CodegenSettingsSchema = z
           "inline_styles",
         ]),
         uiLibrary: z.enum(["mui", "antd", "radix", "shadcn"]).optional(),
+        enableUILibraryTheming: z.boolean().optional(),
       }),
       z.object({
         framework: z.literal("html"),
@@ -41,6 +42,7 @@ export type CodegenSettings = {
     | "inline_styles"
   uiLibrary?: "mui" | "antd" | "radix" | "shadcn";
   enableTranslation?: boolean;
+  enableUILibraryTheming?: boolean;
 };
 
 export const validateSettings = (obj: unknown): CodegenSettings => {


### PR DESCRIPTION
This pull request introduces a new feature to enable UI library theming in the SDK. The changes include updates to the `Anima` class and the `CodegenSettingsSchema` to support this new feature.

Key changes:

* [`sdk/src/anima.ts`](diffhunk://#diff-13b5ddd362ecdcdfbb07d760fabcb129f538d2eb15078e429dd5d68370305740R85): Added `enableUILibraryTheming` to the settings object in the `Anima` class.
* [`sdk/src/settings.ts`](diffhunk://#diff-3dce8b459887cdb063aa9ebb5e6e0829b0dae27eaa27b271755f753125e7b899R21): Updated the `CodegenSettingsSchema` to include the new `enableUILibraryTheming` boolean option.
* [`sdk/src/settings.ts`](diffhunk://#diff-3dce8b459887cdb063aa9ebb5e6e0829b0dae27eaa27b271755f753125e7b899R45): Added `enableUILibraryTheming` to the `CodegenSettings` type definition.