### PR TITLE
feat: add `filePath` and `referencePath` properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,11 +60,22 @@ If you are using `useAnimaCodegen` from `@animaapp/anima-sdk-react`, you have on
 
 ```ts
 const { files } = await useAnimaCodegen({
-  assetsStorage: { strategy: "local", path: "/" },
+  assetsStorage: { strategy: "local", filePath: "public/assets", referencePath: "/" },
+});
+
+// or
+
+const { files } = await useAnimaCodegen({
+  assetsStorage: {
+    strategy: "local",
+    path: "/" // equivalent of `{ filePath: "/", referencePath: "/" }`
+  },
 });
 ```
 
 It downloads all the assets from the client-side and include them in `files` as base64.
+
+The property `filePath` defines where the files are stored in the project, and `referencePath` defines the base path when the source references for a file (e.g., the `src` attribute from `<img />`). If both values are equal, you can use just `path`.
 
 # Publishing
 

--- a/sdk-react/package.json
+++ b/sdk-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@animaapp/anima-sdk-react",
-  "version": "0.1.3",
+  "version": "0.2.0",
   "type": "module",
   "description": "Anima's JavaScript utilities library",
   "author": "Anima App, Inc.",

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@animaapp/anima-sdk",
-  "version": "0.1.3",
+  "version": "0.2.0",
   "type": "module",
   "description": "Anima's JavaScript utilities library",
   "author": "Anima App, Inc.",


### PR DESCRIPTION
Allow to define the file path and reference path separately when using the `"local"` assets strategy.