### PR TITLE
ci: fix publish workflow unable to push to npm registry

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ workflows:
           context: anima-prod
           filters:
             branches:
-              only: ci
+              only: main
 
 jobs:
   publish:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ workflows:
           context: anima-prod
           filters:
             branches:
-              only: main
+              only: ci
 
 jobs:
   publish:

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   },
   "scripts": {
     "build": "turbo run build",
-    "publish": "turbo run build && changeset publish"
+    "publish": "turbo run build && changeset publish --access public"
   },
   "dependencies": {
     "@changesets/cli": "^2.27.12",


### PR DESCRIPTION
Proof that it works:
https://app.circleci.com/pipelines/github/AnimaApp/anima-sdk/10/workflows/6c7f20ab-c2e7-4e24-9bbe-f9bd7099dee2/jobs/12