### PR TITLE
chore: add disableMarkedForExport setting to CodegenSettings

### DIFF
--- a/sdk/src/anima.ts
+++ b/sdk/src/anima.ts
@@ -87,6 +87,7 @@ export class Anima {
         enableCompactStructure: settings.enableCompactStructure,
         enableAutoSplit: settings.enableAutoSplit,
         autoSplitThreshold: settings.autoSplitThreshold,
+        disableMarkedForExport: settings.disableMarkedForExport,
       }),
     });
 

--- a/sdk/src/settings.ts
+++ b/sdk/src/settings.ts
@@ -3,6 +3,7 @@ import { z } from "zod";
 const CodegenSettingsSchema = z
   .object({
     language: z.enum(["typescript", "javascript"]).optional(),
+    disableMarkedForExport: z.boolean().optional(),
   })
   .and(
     z.union([
@@ -51,6 +52,7 @@ export type CodegenSettings = {
   enableCompactStructure?: boolean;
   enableAutoSplit?: boolean;
   autoSplitThreshold?: number;
+  disableMarkedForExport?: boolean;
 };
 
 export const validateSettings = (obj: unknown): CodegenSettings => {


### PR DESCRIPTION
This pull request introduces a new setting to the `CodegenSettings` schema and integrates it into the `Anima` class. The most important changes include adding the `disableMarkedForExport` setting and ensuring it is properly handled in the relevant files.

Changes to `CodegenSettings` schema:

* [`sdk/src/settings.ts`](diffhunk://#diff-3dce8b459887cdb063aa9ebb5e6e0829b0dae27eaa27b271755f753125e7b899R6): Added `disableMarkedForExport` as an optional boolean to the `CodegenSettingsSchema` and `CodegenSettings` type. [[1]](diffhunk://#diff-3dce8b459887cdb063aa9ebb5e6e0829b0dae27eaa27b271755f753125e7b899R6) [[2]](diffhunk://#diff-3dce8b459887cdb063aa9ebb5e6e0829b0dae27eaa27b271755f753125e7b899R55)

Integration into `Anima` class:

* [`sdk/src/anima.ts`](diffhunk://#diff-13b5ddd362ecdcdfbb07d760fabcb129f538d2eb15078e429dd5d68370305740R90): Updated the `Anima` class to include `disableMarkedForExport` in its configuration settings.