### PR TITLE
chore: wrap error from `getFigmaFile`

### DIFF
--- a/sdk-react/package.json
+++ b/sdk-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@animaapp/anima-sdk-react",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "type": "module",
   "description": "Anima's JavaScript utilities library",
   "author": "Anima App, Inc.",

--- a/sdk-react/src/stories/useAnimaCodegen.stories.tsx
+++ b/sdk-react/src/stories/useAnimaCodegen.stories.tsx
@@ -156,7 +156,7 @@ export const InvalidBody: Story = {
   },
 };
 
-export const InvalidJWTTokenFormat: Story = {
+export const InvalidAnimaJWTTokenFormat: Story = {
   play: async (context) => {
     const { error } = await run(context);
 

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@animaapp/anima-sdk",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "type": "module",
   "description": "Anima's JavaScript utilities library",
   "author": "Anima App, Inc.",

--- a/sdk/src/figma/utils.ts
+++ b/sdk/src/figma/utils.ts
@@ -1,6 +1,6 @@
 import type { GetFileResponse, Node } from "@figma/rest-api-spec";
 import { FigmaRestApi } from "@animaapp/http-client-figma";
-import { handleFigmaApiError, type FigmaApiError } from "./figmaError";
+import { wrapFigmaApiError, type FigmaApiError } from "./figmaError";
 
 export type FigmaNode = Node;
 export type GetFileParams = {
@@ -43,9 +43,8 @@ export const getFigmaFile = async ({
 
     return rootFile;
   } catch (error) {
-    // TODO: We probably should call `throw handleFigmaApiError(error)`, as we do on `getFilePages`
     console.error(error);
-    throw error;
+    throw wrapFigmaApiError(error as FigmaApiError, fileKey);
   }
 };
 
@@ -71,7 +70,7 @@ export const getFileNodes = async ({
 
     return data.nodes;
   } catch (error) {
-    return handleFigmaApiError(error as FigmaApiError, fileKey);
+    throw wrapFigmaApiError(error as FigmaApiError, fileKey);
   }
 };
 


### PR DESCRIPTION
Wrap the exceptions thrown from `getFigmaFile` as we do on `getFilePages`.