### PR TITLE
fix(isValidFigmaUrl): reject urls with trailling texts

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,15 +34,23 @@ console.log(files); // High-quality React code from your Figma design!
 
 Check [`example-server`](/example-server) to see a thin example on how to expose an endpoint to call Anima API.
 
+## SDK
+
+### Utils
+
+#### `isValidFigmaUrl`
+
+Check if a given Figma link is a valid design for code generation.
+
 ## Anima SDK for React
 
 We offer an official React package: `@animaapp/anima-sdk-react`.
 
-## Assets Storage
+### Assets Storage
 
 The Figma file may contains assets. You can choose whether to let us host them, or give you the assets links to download then you can host them, or return the assets togheter the source files.
 
-### Have Anima host your assets
+#### Have Anima host your assets
 
 ```ts
 const { files } = await anima.generateCode({
@@ -52,7 +60,7 @@ const { files } = await anima.generateCode({
 
 With the `"host"` strategy, Anima will host the assets files. This is the default strategy.
 
-### Manage your own hosting
+#### Manage your own hosting
 
 ```ts
 const { files, assets } = await anima.generateCode({
@@ -62,7 +70,7 @@ const { files, assets } = await anima.generateCode({
 
 With the `"external"` strategy, the method returns assets in an array of `{ name, url }`. Download each asset from its url and re-upload it at your own hosting.
 
-### Local
+#### Local
 
 If you are using `useAnimaCodegen` from `@animaapp/anima-sdk-react`, you have one additional strategy: `"local"`.
 
@@ -89,6 +97,6 @@ It downloads all the assets from the client-side and include them in `files` as 
 
 The property `filePath` defines where the files are stored in the project, and `referencePath` defines the base path when the source references for a file (e.g., the `src` attribute from `<img />`). If both values are equal, you can use just `path`.
 
-# Development
+## Development
 
 See [`DEVELOPMENT.md`](DEVELOPMENT.md) to learn how to develop the Anima SDK itself - not how to use it on your project.

--- a/sdk-react/package.json
+++ b/sdk-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@animaapp/anima-sdk-react",
-  "version": "0.3.5",
+  "version": "0.3.6",
   "type": "module",
   "description": "Anima's JavaScript utilities library",
   "author": "Anima App, Inc.",

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@animaapp/anima-sdk",
-  "version": "0.3.5",
+  "version": "0.3.6",
   "type": "module",
   "description": "Anima's JavaScript utilities library",
   "author": "Anima App, Inc.",

--- a/sdk/src/utils/figma.spec.ts
+++ b/sdk/src/utils/figma.spec.ts
@@ -1,7 +1,79 @@
 import { describe, expect, it } from "vitest";
-import { formatToFigmaLink } from "./figma";
+import { isValidFigmaUrl, formatToFigmaLink } from "./figma";
 
 describe("# figma", () => {
+  describe(".isValidFigmaUrl", () => {
+    describe("when the URL is malformed", () => {
+      it("returns [false, '', ''] for empty input", () => {
+        const result = isValidFigmaUrl("");
+
+        expect(result).toEqual([false, "", ""]);
+      });
+
+      it("returns [false, '', ''] for non-Figma URLs", () => {
+        const result = isValidFigmaUrl("https://example.com");
+
+        expect(result).toEqual([false, "", ""]);
+      });
+
+      it("returns [false, '', ''] for Figma URLs with text before", () => {
+        const validFileKey = "5d0u9PmD4GtB5fdX57pTtK";
+        const result = isValidFigmaUrl(
+          `some text https://www.figma.com/file/${validFileKey}?node-id=1-2`
+        );
+
+        expect(result).toEqual([false, "", ""]);
+      });
+
+      it("returns [false, '', ''] for Figma URLs with text after", () => {
+        const validFileKey = "5d0u9PmD4GtB5fdX57pTtK";
+        const result = isValidFigmaUrl(
+          `https://www.figma.com/file/${validFileKey}?node-id=1-2 some text`
+        );
+
+        expect(result).toEqual([false, "", ""]);
+      });
+    });
+
+    describe("when the URL is a valid Figma link", () => {
+      it("returns [true, fileKey, ''] for Figma URLs with no node id", () => {
+        const validFileKey = "5d0u9PmD4GtB5fdX57pTtK";
+        const result = isValidFigmaUrl(
+          `https://www.figma.com/file/${validFileKey}`
+        );
+
+        expect(result).toStrictEqual([true, validFileKey, ""]);
+      });
+
+      it("returns [true, fileKey, nodeId] for Figma URLs with only a node id", () => {
+        const validFileKey = "5d0u9PmD4GtB5fdX57pTtK";
+        const result = isValidFigmaUrl(
+          `https://www.figma.com/file/${validFileKey}?node-id=1-2`
+        );
+
+        expect(result).toStrictEqual([true, validFileKey, "1:2"]);
+      });
+
+      it("returns [true, fileKey, nodeId] for Figma URLs with the design name and a node id", () => {
+        const validFileKey = "5d0u9PmD4GtB5fdX57pTtK";
+        const result = isValidFigmaUrl(
+          `https://www.figma.com/file/${validFileKey}/Untitled?node-id=1-2`
+        );
+
+        expect(result).toStrictEqual([true, validFileKey, "1:2"]);
+      });
+
+      it("returns [true, fileKey, nodeId] for Figma URLs with the design name, a node id, and timestamp", () => {
+        const validFileKey = "5d0u9PmD4GtB5fdX57pTtK";
+        const result = isValidFigmaUrl(
+          `https://www.figma.com/file/${validFileKey}/Untitled?node-id=1-2&t=ZTF3vjgiCx7ijjcc-11`
+        );
+
+        expect(result).toStrictEqual([true, validFileKey, "1:2"]);
+      });
+    });
+  });
+
   describe(".formatToFigmaLink", () => {
     it("generates a link with file key and node id", () => {
       const url = formatToFigmaLink({

--- a/sdk/src/utils/figma.ts
+++ b/sdk/src/utils/figma.ts
@@ -13,6 +13,11 @@ export const isValidFigmaUrl = (
       return [false, "", ""];
     }
 
+    const reconstructedUrl = url.toString();
+    if (figmaLink !== reconstructedUrl) {
+      return [false, "", ""];
+    }
+
     const nodeId = (url.searchParams.get("node-id") ?? "").replace(/-/g, ":");
     const fileKey = path.split("/")[2];
     const hasCorrectPrefix =


### PR DESCRIPTION
Some users are writing on the Figma URL input a free text.
They probably think that can be used to write an AI prompt.

This PR improves the `isValidFigmaUrl` function to reject these inputs.
In addition to that, it also documents this function on the readme, and adds more unit tests.

![image](https://github.com/user-attachments/assets/b80f76b3-3ec4-4e38-9cc7-6345381f3e4c)
