### PR TITLE
fix: remove team_id (not relevant for API users)

### DIFF
--- a/example-server/example.env
+++ b/example-server/example.env
@@ -1,4 +1,3 @@
 ANIMA_PUBLIC_URL="https://public-api.animaapp.com"
 ANIMA_ACCESS_TOKEN=
-ANIMA_TEAM_ID=
 FIGMA_TOKEN=

--- a/example-server/src/getAnima.ts
+++ b/example-server/src/getAnima.ts
@@ -6,13 +6,11 @@ config();
 const getAnima = ({
   apiBaseAddress = process.env.ANIMA_PUBLIC_URL,
   token = process.env.ANIMA_ACCESS_TOKEN!,
-  teamId = process.env.ANIMA_TEAM_ID!,
 } = {}) => {
   const anima = new Anima({
     apiBaseAddress,
     auth: {
       token,
-      teamId,
     },
   });
 

--- a/example-server/src/index.ts
+++ b/example-server/src/index.ts
@@ -22,7 +22,6 @@ app.post("/", async (c) => {
 
     const anima = getAnima({
       token: params.animaAccessToken,
-      teamId: params.teamId,
     });
 
     const response = await createCodegenResponseEventStream(anima, {


### PR DESCRIPTION
API users, should only use Anima access token, removing `team_id` from the example