### PR TITLE
fix: avoid missing session id

### DIFF
--- a/sdk-react/package.json
+++ b/sdk-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@animaapp/anima-sdk-react",
-  "version": "0.6.3",
+  "version": "0.6.4",
   "type": "module",
   "description": "Anima's JavaScript utilities library",
   "author": "Anima App, Inc.",

--- a/sdk-react/src/useAnimaCodegen.ts
+++ b/sdk-react/src/useAnimaCodegen.ts
@@ -246,6 +246,7 @@ export const useAnimaCodegen = ({
       es.addEventListener("done", (event) => {
         const message = JSON.parse(event.data) as StreamMessageByType<"done">;
         result.tokenUsage = message.payload.tokenUsage;
+        result.sessionId = message.payload.sessionId;
 
         updateStatus((draft) => {
           draft.status = "success";

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@animaapp/anima-sdk",
-  "version": "0.6.3",
+  "version": "0.6.4",
   "type": "module",
   "description": "Anima's JavaScript utilities library",
   "author": "Anima App, Inc.",

--- a/sdk/src/anima.ts
+++ b/sdk/src/anima.ts
@@ -307,6 +307,7 @@ export class Anima {
                 }
 
                 result.tokenUsage = (data as any).payload.tokenUsage;
+                result.sessionId = (data as any).payload.sessionId;
                 return result as AnimaSDKResult;
               }
             }


### PR DESCRIPTION
If the client didn't receive the `start` message from the server, the session id will be `undefined`.
In order to avoid it happens, let's get the session id sent by the `done` message.