### PR TITLE
fix: add support for `proto` figma links

### DIFF
--- a/sdk-react/package.json
+++ b/sdk-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@animaapp/anima-sdk-react",
-  "version": "0.6.10",
+  "version": "0.6.11",
   "type": "module",
   "description": "Anima's JavaScript utilities library",
   "author": "Anima App, Inc.",

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@animaapp/anima-sdk",
-  "version": "0.6.10",
+  "version": "0.6.11",
   "type": "module",
   "description": "Anima's JavaScript utilities library",
   "author": "Anima App, Inc.",

--- a/sdk/src/utils/figma.spec.ts
+++ b/sdk/src/utils/figma.spec.ts
@@ -71,6 +71,24 @@ describe("# figma", () => {
 
         expect(result).toStrictEqual([true, validFileKey, "1:2"]);
       });
+
+      it("returns [true, fileKey, nodeId] for Figma proto URLs", () => {
+        const validFileKey = "0fRU16KZHqbKtLWtvPM1qA";
+        const result = isValidFigmaUrl(
+          `https://www.figma.com/proto/${validFileKey}/Feedback-report-AI-test?node-id=1-2&t=zmT2FSe5Zv1Jix6a-1`
+        );
+
+        expect(result).toStrictEqual([true, validFileKey, "1:2"]);
+      });
+
+      it("returns [true, fileKey, ''] for Figma proto URLs with no node id", () => {
+        const validFileKey = "0fRU16KZHqbKtLWtvPM1qA";
+        const result = isValidFigmaUrl(
+          `https://www.figma.com/proto/${validFileKey}/Feedback-report-AI-test`
+        );
+
+        expect(result).toStrictEqual([true, validFileKey, ""]);
+      });
     });
   });
 

--- a/sdk/src/utils/figma.ts
+++ b/sdk/src/utils/figma.ts
@@ -23,7 +23,8 @@ export const isValidFigmaUrl = (
     const hasCorrectPrefix =
       (path.startsWith("/file/") &&
         url.searchParams.get("type") !== "whiteboard") ||
-      path.startsWith("/design/");
+      path.startsWith("/design/") ||
+      path.startsWith("/proto/");
 
     return [hasCorrectPrefix && fileKey.length === 22, fileKey, nodeId];
   } catch {


### PR DESCRIPTION
Add support for figma.com/proto links as well