### PR TITLE
feat: add mhtml parameter to generateCodeFromWebsite

### DIFF
--- a/sdk-react/package.json
+++ b/sdk-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@animaapp/anima-sdk-react",
-  "version": "0.6.17",
+  "version": "0.6.18",
   "type": "module",
   "description": "Anima's JavaScript utilities library",
   "author": "Anima App, Inc.",

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@animaapp/anima-sdk",
-  "version": "0.6.17",
+  "version": "0.6.18",
   "type": "module",
   "description": "Anima's JavaScript utilities library",
   "author": "Anima App, Inc.",

--- a/sdk/src/anima.ts
+++ b/sdk/src/anima.ts
@@ -400,14 +400,26 @@ export class Anima {
       }
     }
 
+    let input;
+    if (params.mhtml) {
+      input = {
+        type: "mhtml",
+        mhtml: params.mhtml,
+      };
+    } else if (params.url) {
+      input = {
+        type: "url",
+        url: params.url,
+      };
+    } else {
+      throw new Error("Either 'url' or 'mhtml' must be provided");
+    }
+
     const requestBody = {
       tracking,
       assetsStorage: params.assetsStorage,
       params: {
-        input: {
-          type: "url",
-          url: params.url,
-        },
+        input,
         conventions: {
           framework: params.settings.framework,
           language: params.settings.language,

--- a/sdk/src/anima.ts
+++ b/sdk/src/anima.ts
@@ -405,6 +405,7 @@ export class Anima {
       input = {
         type: "mhtml",
         mhtml: params.mhtml,
+        url: params.url,
       };
     } else if (params.url) {
       input = {

--- a/sdk/src/types.ts
+++ b/sdk/src/types.ts
@@ -116,7 +116,9 @@ export type SSECodegenMessageErrorPayload = {
 };
 
 export type GetCodeFromWebsiteParams = {
-  url: string;
+  url?: string;
+  mhtml?: string;
+
   assetsStorage?: AssetsStorage;
   settings: GetCodeFromWebsiteSettings;
   tracking?: TrackingInfos;


### PR DESCRIPTION
This PR introduces a new `mhtml` parameter that allows the `generateCodeFromWebsite` to accept a MHTML payload instead of a URL.

Note that a URL could also be _optionally_ passed along to enrich the request