### PR TITLE
feat(l2c): add new experimental react engine option

### DIFF
--- a/sdk-react/package.json
+++ b/sdk-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@animaapp/anima-sdk-react",
-  "version": "0.6.23",
+  "version": "0.6.24",
   "type": "module",
   "description": "Anima's JavaScript utilities library",
   "author": "Anima App, Inc.",

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@animaapp/anima-sdk",
-  "version": "0.6.23",
+  "version": "0.6.24",
   "type": "module",
   "description": "Anima's JavaScript utilities library",
   "author": "Anima App, Inc.",

--- a/sdk/src/anima.ts
+++ b/sdk/src/anima.ts
@@ -436,6 +436,11 @@ export class Anima {
       throw new Error("Either 'url' or 'mhtml' must be provided");
     }
 
+    let engine: "react-v2" | undefined = undefined;
+    if (params.experimental_useNewReactEngine) {
+      engine = "react-v2";
+    }
+
     const requestBody = {
       tracking,
       assetsStorage: params.assetsStorage,
@@ -449,6 +454,7 @@ export class Anima {
         assetsStorage: {
           type: "bundled",
         },
+        engine,
       },
     };
 

--- a/sdk/src/types.ts
+++ b/sdk/src/types.ts
@@ -101,6 +101,9 @@ export type GetCodeFromWebsiteParams = {
   settings: GetCodeFromWebsiteSettings;
   tracking?: TrackingInfos;
   webhookUrl?: string;
+
+  // Experimental options, will change in the future.
+  experimental_useNewReactEngine?: boolean;
 };
 
 export type GetCodeFromWebsiteHandler =


### PR DESCRIPTION
Add new experimental option to use the new react engine. Might change in the future, so I've added the `experimental_` prefix to follow the same convention of the Vercel's AI SDK