### PR TITLE
feat: throw early errors

### DIFF
--- a/sdk/src/types.ts
+++ b/sdk/src/types.ts
@@ -184,6 +184,7 @@ export type SSECommonMessage =
     }
   | {
       type: "job_status_updated";
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
       payload: { jobStatus: Record<string, any> };
     }
   | { type: "aborted" };


### PR DESCRIPTION
This PR updates the `error` handler with the following approach: if we had an error on the fetch itself (i.e., 404, 500, network failure), it throws an error on the promise and does not retry.