### PR TITLE
chore: bump sdk and sdk-react to 0.23.1

### DIFF
--- a/sdk-react/package.json
+++ b/sdk-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@animaapp/anima-sdk-react",
-  "version": "0.23.0",
+  "version": "0.23.1",
   "type": "module",
   "description": "Anima's JavaScript utilities library",
   "author": "Anima App, Inc.",

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@animaapp/anima-sdk",
-  "version": "0.23.0",
+  "version": "0.23.1",
   "type": "module",
   "description": "Anima's JavaScript utilities library",
   "author": "Anima App, Inc.",


### PR DESCRIPTION
Bumps both `@animaapp/anima-sdk` and `@animaapp/anima-sdk-react` from 0.23.0 → 0.23.1.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Released version 0.23.1

<!-- end of auto-generated comment: release notes by coderabbit.ai -->