### PR TITLE
feat: p2c fast mode

### DIFF
--- a/sdk-react/package.json
+++ b/sdk-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@animaapp/anima-sdk-react",
-  "version": "0.22.0",
+  "version": "0.22.1-wip1",
   "type": "module",
   "description": "Anima's JavaScript utilities library",
   "author": "Anima App, Inc.",

--- a/sdk-react/package.json
+++ b/sdk-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@animaapp/anima-sdk-react",
-  "version": "0.23.1",
+  "version": "0.23.2",
   "type": "module",
   "description": "Anima's JavaScript utilities library",
   "author": "Anima App, Inc.",

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@animaapp/anima-sdk",
-  "version": "0.23.1",
+  "version": "0.23.2",
   "type": "module",
   "description": "Anima's JavaScript utilities library",
   "author": "Anima App, Inc.",

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@animaapp/anima-sdk",
-  "version": "0.22.0",
+  "version": "0.22.1-wip1",
   "type": "module",
   "description": "Anima's JavaScript utilities library",
   "author": "Anima App, Inc.",

--- a/sdk/src/anima.ts
+++ b/sdk/src/anima.ts
@@ -563,6 +563,7 @@ export class Anima {
           uiLibrary: params.settings.uiLibrary,
         },
         dsId: params.settings.dsId,
+        fastMode: params.settings.fastMode,
         ...(params.settings.codegenSettings ?? {}),
       },
       webhookUrl: params.webhookUrl,

--- a/sdk/src/types.ts
+++ b/sdk/src/types.ts
@@ -184,6 +184,7 @@ export type GetCodeFromPromptSettings = BaseSettings & {
   styling: "tailwind" | "inline_styles";
   uiLibrary?: "shadcn" | "custom_design_system";
   dsId?: string;
+  fastMode?: boolean;
 };
 
 export type AttachToGenerationJobParams = {


### PR DESCRIPTION
## Summary

- Add `fastMode` option to `GetCodeFromPromptSettings`, passed through to the codegen job payload
- Bump SDK and SDK-React to version 0.23.2

## Changes

### `sdk/src/types.ts`
- Add `fastMode?: boolean` to `GetCodeFromPromptSettings`
- Extend `ProgressMessage.status` union with `"failure"`

### `sdk/src/anima.ts`
- Forward `fastMode` from settings into the job request payload

### `sdk-react/src/job.ts`
- Detect `failure` status in the streaming subscription and resolve with a `CodegenError` containing the error detail

### `sdk-react/src/AnimaSdkProvider.tsx`
- Widen the error type on the `Job` to include `CodegenError`

## Test plan

- [ ] Trigger a prompt-to-code generation with `fastMode: true` and verify the flag is sent in the job payload
- [ ] Trigger a prompt-to-code generation with `fastMode: false` / omitted and verify backward compatibility
- [ ] Simulate a generation failure and confirm the error is surfaced with the correct detail message

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced an optional `fastMode` parameter for code generation requests, providing users with additional configuration options.

* **Chores**
  * Released version 0.23.2 for both SDK and SDK React packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->