### PR TITLE
feat: add l2c vanilla css sdk params

### DIFF
--- a/.changeset/l2c-vanilla-css.md
+++ b/.changeset/l2c-vanilla-css.md
@@ -1,0 +1,5 @@
+---
+"@animaapp/anima-sdk": patch
+---
+
+Allow website-to-code requests to opt into HTML vanilla CSS output and pass HTML optimization toggles.

--- a/.changeset/l2c-vanilla-css.md
+++ b/.changeset/l2c-vanilla-css.md
@@ -1,5 +1,0 @@
----
-"@animaapp/anima-sdk": patch
----
-
-Allow website-to-code requests to opt into HTML vanilla CSS output and pass HTML optimization toggles.

--- a/sdk-react/package.json
+++ b/sdk-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@animaapp/anima-sdk-react",
-  "version": "0.23.2",
+  "version": "0.23.3",
   "type": "module",
   "description": "Anima's JavaScript utilities library",
   "author": "Anima App, Inc.",

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@animaapp/anima-sdk",
-  "version": "0.23.2",
+  "version": "0.23.3",
   "type": "module",
   "description": "Anima's JavaScript utilities library",
   "author": "Anima App, Inc.",

--- a/sdk/src/anima.ts
+++ b/sdk/src/anima.ts
@@ -492,6 +492,7 @@ export class Anima {
           type: "bundled",
         },
         engine,
+        htmlOptimizations: params.htmlOptimizations,
       },
     };
 

--- a/sdk/src/types.ts
+++ b/sdk/src/types.ts
@@ -111,9 +111,16 @@ export type GetCodeFromWebsiteParams = {
   prompt?: string;
   images?: Array<{ url: string }>;
   dsId?: string;
+  htmlOptimizations?: GetCodeFromWebsiteHTMLOptimizations;
 
   // Experimental options, will change in the future.
   experimental_useNewReactEngine?: boolean;
+};
+
+export type GetCodeFromWebsiteHTMLOptimizations = {
+  extractInlineAssets?: boolean;
+  pruneComputedCSSNoise?: boolean;
+  factorRepeatedCSSDeclarations?: boolean;
 };
 
 export type GetCodeFromWebsiteHandler =
@@ -142,7 +149,7 @@ export type GetCodeFromWebsiteHandler =
 export type GetCodeFromWebsiteSettings = BaseSettings & {
   language?: "typescript";
   framework: "react" | "html";
-  styling: "tailwind" | "inline_styles";
+  styling: "tailwind" | "inline_styles" | "vanilla_css";
   uiLibrary?: "shadcn";
 };
 
@@ -301,7 +308,11 @@ export type L2CParamsLanguage = "typescript";
 /**
  * @deprecated This type is deprecated and will be removed soon.
  */
-export type L2CParamsStyling = "tailwind" | "inline-styles";
+export type L2CParamsStyling =
+  | "tailwind"
+  | "inline-styles"
+  | "inline_styles"
+  | "vanilla_css";
 
 /**
  * @deprecated This type is deprecated and will be removed soon.
@@ -350,6 +361,7 @@ export type L2CParams = {
   conventions: L2CParamsConvention;
   assetsStorage: L2CParamsAssetsStorage;
   viewports?: Array<"desktop" | "tablet" | "mobile">;
+  htmlOptimizations?: GetCodeFromWebsiteHTMLOptimizations;
 };
 
 /**


### PR DESCRIPTION
Add SDK request params for L2C HTML vanilla CSS output

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added HTML optimization options for website-to-code generation (inline asset extraction, CSS pruning, repeated-declaration factoring).
  * Added new styling options: vanilla_css and inline_styles.

* **Chores**
  * Bumped SDK and SDK React package versions to 0.23.3.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/AnimaApp/anima-sdk/pull/86?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->