### PR TITLE
fix: publish sdk packages explicitly

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,7 +58,22 @@ jobs:
             echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" >> .npmrc
       - run:
           name: Publish to NPM
-          command: pnpm exec changeset publish --no-git-checks
+          command: |
+            publish_if_missing() {
+              package_dir="$1"
+              package_name="$(node -p "require('./${package_dir}/package.json').name")"
+              package_version="$(node -p "require('./${package_dir}/package.json').version")"
+
+              if npm view "${package_name}@${package_version}" version --registry=https://registry.npmjs.org >/dev/null 2>&1; then
+                echo "${package_name}@${package_version} already exists on NPM; skipping"
+                return
+              fi
+
+              npm publish "./${package_dir}" --access public --registry=https://registry.npmjs.org
+            }
+
+            publish_if_missing sdk
+            publish_if_missing sdk-react
       - run:
           name: Set .npmrc for GitHub Packages publish
           command: |
@@ -68,4 +83,19 @@ jobs:
             echo "//npm.pkg.github.com/:_authToken=$GITHUB_PACKAGE_TOKEN" >> .npmrc
       - run:
           name: Publish to GitHub Packages
-          command: pnpm exec changeset publish --no-git-checks
+          command: |
+            publish_if_missing() {
+              package_dir="$1"
+              package_name="$(node -p "require('./${package_dir}/package.json').name")"
+              package_version="$(node -p "require('./${package_dir}/package.json').version")"
+
+              if npm view "${package_name}@${package_version}" version --registry=https://npm.pkg.github.com >/dev/null 2>&1; then
+                echo "${package_name}@${package_version} already exists on GitHub Packages; skipping"
+                return
+              fi
+
+              npm publish "./${package_dir}" --registry=https://npm.pkg.github.com
+            }
+
+            publish_if_missing sdk
+            publish_if_missing sdk-react

--- a/sdk-react/package.json
+++ b/sdk-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@animaapp/anima-sdk-react",
-  "version": "0.23.3",
+  "version": "0.23.5",
   "type": "module",
   "description": "Anima's JavaScript utilities library",
   "author": "Anima App, Inc.",

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@animaapp/anima-sdk",
-  "version": "0.23.3",
+  "version": "0.23.5",
   "type": "module",
   "description": "Anima's JavaScript utilities library",
   "author": "Anima App, Inc.",


### PR DESCRIPTION
## Summary
- replace Changesets publish in CircleCI with explicit guarded package publishes
- skip publish when the package version already exists in the target registry

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Released SDK and SDK React version 0.23.5
  * Enhanced package publishing workflow with improved version detection to prevent duplicate releases

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/AnimaApp/anima-sdk/pull/87?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->