### PR TITLE
feat: add imageMode setting to p2c

### DIFF
--- a/sdk-react/package.json
+++ b/sdk-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@animaapp/anima-sdk-react",
-  "version": "0.24.1-wip1",
+  "version": "0.25.0",
   "type": "module",
   "description": "Anima's JavaScript utilities library",
   "author": "Anima App, Inc.",

--- a/sdk-react/package.json
+++ b/sdk-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@animaapp/anima-sdk-react",
-  "version": "0.24.0",
+  "version": "0.24.1-wip1",
   "type": "module",
   "description": "Anima's JavaScript utilities library",
   "author": "Anima App, Inc.",

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@animaapp/anima-sdk",
-  "version": "0.24.0",
+  "version": "0.24.1-wip1",
   "type": "module",
   "description": "Anima's JavaScript utilities library",
   "author": "Anima App, Inc.",

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@animaapp/anima-sdk",
-  "version": "0.24.1-wip1",
+  "version": "0.25.0",
   "type": "module",
   "description": "Anima's JavaScript utilities library",
   "author": "Anima App, Inc.",

--- a/sdk/src/anima.ts
+++ b/sdk/src/anima.ts
@@ -566,6 +566,7 @@ export class Anima {
         },
         dsId: params.settings.dsId,
         fastMode: params.settings.fastMode,
+        imageMode: params.settings.imageMode,
         ...(params.settings.codegenSettings ?? {}),
       },
       webhookUrl: params.webhookUrl,

--- a/sdk/src/types.ts
+++ b/sdk/src/types.ts
@@ -193,6 +193,23 @@ export type GetCodeFromPromptSettings = BaseSettings & {
   uiLibrary?: "shadcn" | "custom_design_system";
   dsId?: string;
   fastMode?: boolean;
+  /**
+   * Hard override for the p2c routing classifier.
+   *
+   * - `true`  — Skip the LLM-driven classifier entirely and run the
+   *   image-to-code sub-agent directly. **Bypasses the multi-screen
+   *   safety check** — the caller is responsible for ensuring the
+   *   attached image is a single screen, not a multi-screen prototype /
+   *   moodboard. Saves ~1s + a vision LLM call per request.
+   * - `false` — Skip the classifier and force creative mode.
+   * - unset   — The agent decides automatically: a vision LLM call
+   *   classifies the intent and downgrades multi-screen inputs to
+   *   creative mode as a safety net.
+   *
+   * Requires at least one attached image. With no image attached this
+   * field has no effect.
+   */
+  imageMode?: boolean;
 };
 
 export type AttachToGenerationJobParams = {


### PR DESCRIPTION
## Summary

Adds an `imageMode?: boolean` field to `GetCodeFromPromptSettings` and forwards it on `/v1/p2c` requests as a hard override for the agent's routing classifier.

- **`true`** — Skip the LLM-driven classifier entirely and run the image-to-code sub-agent directly. **Bypasses the multi-screen safety check** — the caller is responsible for ensuring the attached image is a single screen, not a multi-screen prototype / moodboard. Saves ~1s + a vision LLM call per request.
- **`false`** — Force creative mode.
- **unset** — Agent decides automatically (current behaviour, fully preserved for every existing caller).


🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `imageMode` option to control image-to-code generation behavior—force direct image processing, switch to creative mode, or enable auto-classification.

* **Chores**
  * Version bumped to 0.25.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->