### PR TITLE
feat: expose L2C subpages

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,35 @@ const { files } = await anima.generateCodeFromWebsite({
 console.log(files); // High-quality React code from your website!
 ```
 
+#### Discover Website Subpages
+
+```ts
+import { Anima } from "@animaapp/anima-sdk";
+
+const anima = new Anima({
+  auth: {
+    token: "Your Anima Token",
+    teamId: "Your Anima Team ID",
+  },
+});
+
+const { subpages } = await anima.discoverSubpages({
+  url: "https://www.example.com",
+});
+
+const { files } = await anima.generateCodeFromWebsite({
+  url: "https://www.example.com",
+  subpages,
+  settings: {
+    framework: "react",
+    language: "typescript",
+    styling: "tailwind",
+  },
+});
+
+console.log(files);
+```
+
 #### Convert Private Websites to Code (Early Preview)
 
 When you need to generate code from non-public websites (such as internal dashboards), the Anima SDK supports MHTML payloads. These can be generated using [Anima's Website Importer Chrome extension](https://chromewebstore.google.com/detail/anima-website-importer/paddhneaanoeljlmdepnheehdkaegblo).

--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ const anima = new Anima({
 const { subpages } = await anima.discoverSubpages({
   url: "https://www.example.com",
 });
+// subpages: Array<{ url: string }>
 
 const { files } = await anima.generateCodeFromWebsite({
   url: "https://www.example.com",

--- a/sdk-react/package.json
+++ b/sdk-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@animaapp/anima-sdk-react",
-  "version": "0.24.1",
+  "version": "0.25.0",
   "type": "module",
   "description": "Anima's JavaScript utilities library",
   "author": "Anima App, Inc.",

--- a/sdk-react/package.json
+++ b/sdk-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@animaapp/anima-sdk-react",
-  "version": "0.24.0",
+  "version": "0.24.1",
   "type": "module",
   "description": "Anima's JavaScript utilities library",
   "author": "Anima App, Inc.",

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@animaapp/anima-sdk",
-  "version": "0.24.0",
+  "version": "0.24.1",
   "type": "module",
   "description": "Anima's JavaScript utilities library",
   "author": "Anima App, Inc.",

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@animaapp/anima-sdk",
-  "version": "0.24.1",
+  "version": "0.25.0",
   "type": "module",
   "description": "Anima's JavaScript utilities library",
   "author": "Anima App, Inc.",

--- a/sdk/src/anima.ts
+++ b/sdk/src/anima.ts
@@ -1,11 +1,17 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { GetFileResponse } from "@figma/rest-api-spec";
 import { gzip } from "pako";
-import { CodegenError, CodegenRouteErrorReason } from "./errors";
+import {
+  CodegenError,
+  CodegenRouteErrorReason,
+  DiscoverSubpagesErrorReason,
+} from "./errors";
 import { validateSettings } from "./settings";
 import {
   AnimaSDKResult,
   AttachToGenerationJobParams,
+  DiscoverSubpagesParams,
+  DiscoverSubpagesResult,
   GetCodeFromWebsiteHandler,
   GetCodeFromWebsiteParams,
   GetCodeFromPromptHandler,
@@ -493,6 +499,7 @@ export class Anima {
         },
         engine,
         htmlOptimizations: params.htmlOptimizations,
+        subpages: params.subpages,
         ...(params.settings.codegenSettings ?? {}),
       },
     };
@@ -505,6 +512,48 @@ export class Anima {
       "l2c",
       signal
     );
+  }
+
+  async discoverSubpages(
+    params: DiscoverSubpagesParams,
+    signal?: AbortSignal,
+  ): Promise<DiscoverSubpagesResult> {
+    if (this.hasAuth() === false) {
+      throw new Error('It needs to set "auth" before calling this method.');
+    }
+
+    const response = await fetch(
+      `${this.#apiBaseAddress}/v1/l2c/discover-subpages`,
+      {
+        method: "POST",
+        headers: this.headers,
+        body: JSON.stringify(params),
+        signal,
+      },
+    );
+
+    if (!response.ok) {
+      const errorText = await response.text();
+      let errorMessage = errorText;
+
+      try {
+        const errorBody = JSON.parse(errorText);
+        if (typeof errorBody?.error === "string") {
+          errorMessage = errorBody.error;
+        } else if (typeof errorBody?.message === "string") {
+          errorMessage = errorBody.message;
+        }
+      } catch {}
+
+      throw new CodegenError({
+        name: "HTTP error from Anima API",
+        reason: (errorMessage ||
+          "Failed to discover website subpages") as DiscoverSubpagesErrorReason,
+        status: response.status,
+      });
+    }
+
+    return response.json() as Promise<DiscoverSubpagesResult>;
   }
 
   /**

--- a/sdk/src/errors.ts
+++ b/sdk/src/errors.ts
@@ -53,6 +53,14 @@ export type SDKErrorReason =
 export type GetCodeFromWebsiteErrorReason = "Scraping is blocked" | "Unknown";
 
 /**
+ * Errors from website subpage discovery.
+ */
+export type DiscoverSubpagesErrorReason =
+  | "Subpage discovery requires a paid plan"
+  | "Website subpage discovery timed out after 10 seconds"
+  | "Failed to discover website subpages";
+
+/**
  * Errors from the Prompt To Code Flow
  */
 export type GetCodeFromPromptErrorReason =
@@ -77,6 +85,7 @@ export class CodegenError extends Error {
       | CodegenRouteErrorReason
       | SDKErrorReason
       | GetCodeFromWebsiteErrorReason
+      | DiscoverSubpagesErrorReason
       | GetCodeFromPromptErrorReason;
     status?: number;
     detail?: unknown;

--- a/sdk/src/types.ts
+++ b/sdk/src/types.ts
@@ -112,9 +112,18 @@ export type GetCodeFromWebsiteParams = {
   images?: Array<{ url: string }>;
   dsId?: string;
   htmlOptimizations?: GetCodeFromWebsiteHTMLOptimizations;
+  subpages?: string[];
 
   // Experimental options, will change in the future.
   experimental_useNewReactEngine?: boolean;
+};
+
+export type DiscoverSubpagesParams = {
+  url: string;
+};
+
+export type DiscoverSubpagesResult = {
+  subpages: string[];
 };
 
 export type GetCodeFromWebsiteHTMLOptimizations = {

--- a/sdk/src/types.ts
+++ b/sdk/src/types.ts
@@ -98,6 +98,10 @@ export type GeneratingCodePayload = {
   files: AnimaFiles;
 };
 
+export type WebsiteSubpage = {
+  url: string;
+};
+
 export type GetCodeFromWebsiteParams = {
   url?: string;
   /** @deprecated Use `mhtmlUrl` instead. */
@@ -112,7 +116,7 @@ export type GetCodeFromWebsiteParams = {
   images?: Array<{ url: string }>;
   dsId?: string;
   htmlOptimizations?: GetCodeFromWebsiteHTMLOptimizations;
-  subpages?: string[];
+  subpages?: WebsiteSubpage[];
 
   // Experimental options, will change in the future.
   experimental_useNewReactEngine?: boolean;
@@ -123,7 +127,7 @@ export type DiscoverSubpagesParams = {
 };
 
 export type DiscoverSubpagesResult = {
-  subpages: string[];
+  subpages: WebsiteSubpage[];
 };
 
 export type GetCodeFromWebsiteHTMLOptimizations = {


### PR DESCRIPTION
## Overview

- New `subpages` param in L2C generation
- New method to expose the `/v1/l2c/discover-subpages` endpoint of Anima Public

## Related PRs
- https://github.com/AnimaApp/anima-design-to-code/pull/4735

## Loom
https://www.loom.com/share/4bab33f02de14ad6917f57f02354bcc1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added website subpage discovery to the SDK, including a new API to fetch discovered subpages.
  * Updated code generation to support discovered subpages so generated output can account for additional site pages.

* **Documentation**
  * Expanded the “Convert Websites to Code” documentation with a “Discover Website Subpages” section and a TypeScript example.

* **Chores**
  * Bumped the main SDK and React SDK versions to **0.25.0**.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->