### PR TITLE
feat: surface image-to-code viewport on AnimaSDKResult

### DIFF
--- a/sdk-react/package.json
+++ b/sdk-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@animaapp/anima-sdk-react",
-  "version": "0.26.0",
+  "version": "0.27.0",
   "type": "module",
   "description": "Anima's JavaScript utilities library",
   "author": "Anima App, Inc.",

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@animaapp/anima-sdk",
-  "version": "0.26.0",
+  "version": "0.27.0",
   "type": "module",
   "description": "Anima's JavaScript utilities library",
   "author": "Anima App, Inc.",

--- a/sdk/src/anima.ts
+++ b/sdk/src/anima.ts
@@ -345,6 +345,23 @@ export class Anima {
               case "done": {
                 result.tokenUsage = (data as any).payload.tokenUsage;
                 result.sessionId = (data as any).payload.sessionId;
+                // Image-mode-only fields.
+                const metadata = (data as any).payload?.metadata;
+                if (metadata && typeof metadata === "object") {
+                  const viewport = (metadata as Record<string, unknown>).viewport;
+                  if (
+                    viewport === "desktop" ||
+                    viewport === "mobile" ||
+                    viewport === "tablet"
+                  ) {
+                    result.viewport = viewport;
+                  }
+                  const viewportReason = (metadata as Record<string, unknown>)
+                    .viewportReason;
+                  if (typeof viewportReason === "string") {
+                    result.viewportReason = viewportReason;
+                  }
+                }
                 return result as AnimaSDKResult;
               }
             }

--- a/sdk/src/types.ts
+++ b/sdk/src/types.ts
@@ -31,9 +31,16 @@ export type BaseResult = {
   tokenUsage: number;
 };
 
+export type ImageToCodeViewport = "desktop" | "mobile" | "tablet";
+
 export type AnimaSDKResult = BaseResult & {
   files: AnimaFiles;
   assets?: Array<{ name: string; url: string }>;
+  /**
+   * Image-mode only. 
+   */
+  viewport?: ImageToCodeViewport;
+  viewportReason?: string;
 };
 
 export type CodegenResult = BaseResult & {


### PR DESCRIPTION
## Summary

- Adds optional `viewport` (`'desktop'|'mobile'|'tablet'`) and `viewportReason` (one-sentence rationale) to `AnimaSDKResult`.
- Unpacks both from the `done` SSE event's `payload.metadata` alongside the existing `sessionId` / `tokenUsage` fields. Image-mode p2c runs (when the worker is on the matching version) surface these; every other generation path leaves them undefined.
- Defensive unpacking — when the worker doesn't emit these fields, the SDK result fields stay undefined, so the SDK + worker can roll forward independently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Image-to-code mode now detects and reports the target device viewport (desktop, mobile, or tablet) in results, with viewport determination reasoning included.

* **Chores**
  * Bumped SDK and SDK-React package versions to 0.27.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->